### PR TITLE
Add go build for unexperienced users (like me)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ If you have Go installed and configured (i.e. with `$GOPATH/bin` in your `$PATH`
 
 ```
 go get -u github.com/tomnomnom/assetfinder
+go build $HOME/go/src/github.com/tomnomnom/assetfinder 
 ```
 
 Otherwise [download a release for your platform](https://github.com/tomnomnom/assetfinder/releases).


### PR DESCRIPTION
Add the `go build` step to the install instructions

I'm new to GO and tried to install via `go get`, it took me a while to realize that I had to run `go build` in order to make it work.
