### PR TITLE
Add findsubdomains.com as a source

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,11 @@ Please feel free to issue pull requests with new sources! :)
     * You need to be careful with your app's rate limits
 * virustotal
     * Needs `VT_API_KEY` environment variable set
+* findsubdomains
+    * Needs `SPYSE_API_TOKEN` environment variable set
 
 ### Sources to be implemented
 * http://api.passivetotal.org/api/docs/
-* https://findsubdomains.com
 * https://community.riskiq.com/ (?)
 * https://riddler.io/
 * http://www.dnsdb.org/

--- a/findsubdomains.go
+++ b/findsubdomains.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func fetchFindSubDomains(domain string) ([]string, error) {
+
+	apiToken := os.Getenv("SPYSE_API_TOKEN")
+	if apiToken == "" {
+		// Must have an API token
+		return []string{}, nil
+	}
+
+	fetchURL := fmt.Sprintf(
+		"https://api.spyse.com/v1/subdomains-aggregate?api_token=%s&domain=%s",
+		apiToken, domain,
+	)
+
+	out := make([]string, 0)
+
+	type Cidr struct {
+		Results []struct {
+			Data struct {
+				Domains []string `json:"domains"`
+			} `json:"data"`
+		} `json:"results"`
+		Count int `json:"count"`
+	}
+
+	type Cidrs struct {
+		Cidr16, Cidr24 Cidr
+	}
+
+	wrapper := struct {
+		Cidrs Cidrs `json:"cidr"`
+	}{}
+	
+	
+	err := fetchJSON(fetchURL, &wrapper)
+
+	for _, result := range wrapper.Cidrs.Cidr16.Results {
+		for _, domain := range result.Data.Domains {
+			out = append(out, domain)
+		}
+	}
+	for _, result := range wrapper.Cidrs.Cidr24.Results {
+		for _, domain := range result.Data.Domains {
+			out = append(out, domain)
+		}
+	}
+
+	return out, err
+}

--- a/findsubdomains.go
+++ b/findsubdomains.go
@@ -26,7 +26,6 @@ func fetchFindSubDomains(domain string) ([]string, error) {
 				Domains []string `json:"domains"`
 			} `json:"data"`
 		} `json:"results"`
-		Count int `json:"count"`
 	}
 
 	type Cidrs struct {

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ func main() {
 		fetchFacebook,
 		//fetchWayback, // A little too slow :(
 		fetchVirusTotal,
+		fetchFindSubDomains,
 	}
 
 	out := make(chan string)


### PR DESCRIPTION
Add code to query findsubdomains.com.
Requires `SPYSE_API_TOKEN` environment variable set