### PR TITLE
added support for Certspotter API

### DIFF
--- a/certspotter.go
+++ b/certspotter.go
@@ -2,13 +2,15 @@ package main
 
 import (
 	"fmt"
+	"os"
 )
 
 func fetchCertSpotter(domain string) ([]string, error) {
 	out := make([]string, 0)
 
-	fetchURL := fmt.Sprintf("https://certspotter.com/api/v0/certs?domain=%s", domain)
-
+	apiKey := os.Getenv("CERTSPOTTER_API_KEY")
+	fetchURL := fmt.Sprintf("https://%s@api.certspotter.com/v1/issuances?domain=%s&expand=dns_names&include_subdomains=true", apiKey, domain)	
+	
 	wrapper := []struct {
 		DNSNames []string `json:"dns_names"`
 	}{}


### PR DESCRIPTION
Adds the option for the user to have a custom Certspotter API key, using the CERTSPOTTER_API_KEY environment variable.

Certspotter allows for API auth using the API key as the username in a HTTP request. Therefore should no key exist, the URL will gracefully still resolve.

Also, updated the Certspotter URL to the v1 API.

Additional info can be found here: https://sslmate.com/certspotter/api/docs-v1