### PR TITLE
Source exclusion patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,4 @@ Please feel free to issue pull requests with new sources! :)
 * https://certdb.com/api-documentation
 
 ## TODO
-* Flags to control which sources are used
-    * Likely to be all on by default and a flag to disable
 * Read domains from stdin


### PR DESCRIPTION
I've implemented the source exclusion flag for myself and thought it could be useful for someone else, so here it is.
The patch is pretty lightweight and it only requires functions to be named correctly since it uses reflection to match user's input to functions being executed.