### PR TITLE
Replacing Deprecated go get command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Find domains and subdomains potentially related to a given domain.
 If you have Go installed and configured (i.e. with `$GOPATH/bin` in your `$PATH`):
 
 ```
-go get -u github.com/tomnomnom/assetfinder
+go install github.com/tomnomnom/assetfinder@latest
 ```
 
 Otherwise [download a release for your platform](https://github.com/tomnomnom/assetfinder/releases).


### PR DESCRIPTION
Updating deprecated `go get` command to use `go install`