### PR TITLE
Update golang installation to fit newer golang versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Find domains and subdomains potentially related to a given domain.
 If you have Go installed and configured (i.e. with `$GOPATH/bin` in your `$PATH`):
 
 ```
-go get -u github.com/tomnomnom/assetfinder
+go install -v github.com/tomnomnom/assetfinder@latest
 ```
 
 Otherwise [download a release for your platform](https://github.com/tomnomnom/assetfinder/releases).


### PR DESCRIPTION
- On the newer golang versions `go get` isn't allowed outside modules anymore, I edited the installation command to work with the newer golang versions 