### PR TITLE
Update README.md, (replace old go syntax with new go syntax)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Find domains and subdomains potentially related to a given domain.
 
 ## Install
 
-If you have Go installed and configured (i.e. with `$GOPATH/bin` in your `$PATH`):
+If you have the latest version of Go installed and configured (i.e. with `$GOPATH/bin` in your `$PATH`):
 
 ```
-go get -u github.com/tomnomnom/assetfinder
+go install github.com/tomnomnom/assetfinder@latest
 ```
 
 Otherwise [download a release for your platform](https://github.com/tomnomnom/assetfinder/releases).


### PR DESCRIPTION
changed the old go syntax to the newer go syntax.
go get no longer works you now need to run go install  -u flag no longer works you need to remove it completely  and you need to add @latest at the end of the GitHub link or @"version" (replace the "version" with the version you need)